### PR TITLE
Reduce bashism (brace expansion)

### DIFF
--- a/main.py
+++ b/main.py
@@ -127,7 +127,6 @@ def main(args):
 #    os.system("sed -i '0,/@var/{s,@var,@.snapshots/var/var-tmp,}' /mnt/etc/fstab")
     os.system("sed -i '0,/@boot/{s,@boot,@.snapshots/boot/boot-tmp,}' /mnt/etc/fstab")
     os.system("mkdir -p /mnt/.snapshots/ast/snapshots")
-    os.system("arch-chroot /mnt btrfs sub set-default /.snapshots/rootfs/snapshot-tmp")
 
     os.system("arch-chroot /mnt ln -s /.snapshots/ast /var/lib/ast")    
 
@@ -224,6 +223,7 @@ def main(args):
         os.system("btrfs sub snap -r /mnt/.snapshots/boot/boot-tmp /mnt/.snapshots/boot/boot-1")
         os.system("btrfs sub snap -r /mnt/.snapshots/etc/etc-tmp /mnt/.snapshots/etc/etc-1")
         os.system("btrfs sub snap /mnt/.snapshots/rootfs/snapshot-1 /mnt/.snapshots/rootfs/snapshot-tmp")
+        os.system("arch-chroot /mnt btrfs sub set-default /.snapshots/rootfs/snapshot-tmp")
 
     elif DesktopInstall == 2:
         os.system(f"echo '1' > /mnt/usr/share/ast/snap")

--- a/main.py
+++ b/main.py
@@ -215,7 +215,7 @@ def main(args):
         os.system("btrfs sub create /mnt/.snapshots/boot/boot-tmp")
 #        os.system("cp --reflink=auto -r /mnt/var/* /mnt/.snapshots/var/var-tmp")
         for i in ("pacman", "systemd"):
-		    os.system(f"mkdir -p /mnt/.snapshots/var/var-tmp/lib/{i}")
+            os.system(f"mkdir -p /mnt/.snapshots/var/var-tmp/lib/{i}")
         os.system("cp --reflink=auto -r /mnt/var/lib/pacman/* /mnt/.snapshots/var/var-tmp/lib/pacman/")
         os.system("cp --reflink=auto -r /mnt/var/lib/systemd/* /mnt/.snapshots/var/var-tmp/lib/systemd/")
         os.system("cp --reflink=auto -r /mnt/boot/* /mnt/.snapshots/boot/boot-tmp")
@@ -271,7 +271,7 @@ def main(args):
         os.system("btrfs sub create /mnt/.snapshots/boot/boot-tmp")
 #        os.system("cp --reflink=auto -r /mnt/var/* /mnt/.snapshots/var/var-tmp")
         for i in ("pacman", "systemd"):
-		    os.system(f"mkdir -p /mnt/.snapshots/var/var-tmp/lib/{i}")
+            os.system(f"mkdir -p /mnt/.snapshots/var/var-tmp/lib/{i}")
         os.system("cp --reflink=auto -r /mnt/var/lib/pacman/* /mnt/.snapshots/var/var-tmp/lib/pacman/")
         os.system("cp --reflink=auto -r /mnt/var/lib/systemd/* /mnt/.snapshots/var/var-tmp/lib/systemd/")
         os.system("cp --reflink=auto -r /mnt/boot/* /mnt/.snapshots/boot/boot-tmp")

--- a/main.py
+++ b/main.py
@@ -67,9 +67,11 @@ def main(args):
     for mntdir in mntdirs:
         os.system(f"mkdir /mnt/{mntdir}")
         os.system(f"mount {args[1]} -o subvol={btrdirs[mntdirs.index(mntdir)]},compress=zstd,noatime /mnt/{mntdir}")
-
-    os.system("mkdir -p /mnt/{tmp,root}")
-    os.system("mkdir -p /mnt/.snapshots/{ast,boot,etc,root,rootfs,tmp,var}")
+    
+    for i in ("tmp", "root"):
+        os.system(f"mkdir -p /mnt/{i}")
+    for i in ("ast", "boot", "etc", "root", "rootfs", "tmp", "var"):
+        os.system(f"mkdir -p /mnt/.snapshots/{i}")
 
     if efi:
         os.system("mkdir /mnt/boot/efi")
@@ -158,7 +160,8 @@ def main(args):
     os.system("btrfs sub create /mnt/.snapshots/var/var-tmp")
     os.system("btrfs sub create /mnt/.snapshots/boot/boot-tmp")
 #    os.system("cp --reflink=auto -r /mnt/var/* /mnt/.snapshots/var/var-tmp")
-    os.system("mkdir -p /mnt/.snapshots/var/var-tmp/lib/{pacman,systemd}")
+    for i in ("pacman", "systemd"):
+        os.system(f"mkdir -p /mnt/.snapshots/var/var-tmp/lib/{i}")
     os.system("cp --reflink=auto -r /mnt/var/lib/pacman/* /mnt/.snapshots/var/var-tmp/lib/pacman/")
     os.system("cp --reflink=auto -r /mnt/var/lib/systemd/* /mnt/.snapshots/var/var-tmp/lib/systemd/")
     os.system("cp --reflink=auto -r /mnt/boot/* /mnt/.snapshots/boot/boot-tmp")
@@ -211,7 +214,8 @@ def main(args):
         os.system("btrfs sub create /mnt/.snapshots/var/var-tmp")
         os.system("btrfs sub create /mnt/.snapshots/boot/boot-tmp")
 #        os.system("cp --reflink=auto -r /mnt/var/* /mnt/.snapshots/var/var-tmp")
-        os.system("mkdir -p /mnt/.snapshots/var/var-tmp/lib/{pacman,systemd}")
+        for i in ("pacman", "systemd"):
+		    os.system(f"mkdir -p /mnt/.snapshots/var/var-tmp/lib/{i}")
         os.system("cp --reflink=auto -r /mnt/var/lib/pacman/* /mnt/.snapshots/var/var-tmp/lib/pacman/")
         os.system("cp --reflink=auto -r /mnt/var/lib/systemd/* /mnt/.snapshots/var/var-tmp/lib/systemd/")
         os.system("cp --reflink=auto -r /mnt/boot/* /mnt/.snapshots/boot/boot-tmp")
@@ -266,7 +270,8 @@ def main(args):
         os.system("btrfs sub create /mnt/.snapshots/var/var-tmp")
         os.system("btrfs sub create /mnt/.snapshots/boot/boot-tmp")
 #        os.system("cp --reflink=auto -r /mnt/var/* /mnt/.snapshots/var/var-tmp")
-        os.system("mkdir -p /mnt/.snapshots/var/var-tmp/lib/{pacman,systemd}")
+        for i in ("pacman", "systemd"):
+		    os.system(f"mkdir -p /mnt/.snapshots/var/var-tmp/lib/{i}")
         os.system("cp --reflink=auto -r /mnt/var/lib/pacman/* /mnt/.snapshots/var/var-tmp/lib/pacman/")
         os.system("cp --reflink=auto -r /mnt/var/lib/systemd/* /mnt/.snapshots/var/var-tmp/lib/systemd/")
         os.system("cp --reflink=auto -r /mnt/boot/* /mnt/.snapshots/boot/boot-tmp")


### PR DESCRIPTION
We should not assume shell to be always 'bash'. For instance, in Debian, sh is defaulted to dash.
As dash does not have brace expansion, mkdir commands as they were in previous commits were creating one directory with weird name `{tmp, var}` instead of two directories!

I would like to make the script as POSIX-compliant as possible!

Note: I know I could have used `python list comprehension` for a one-liner or `os.mkdir()` or `os.makedirs()` but I chose to go with simplicity.