### PR TITLE
Fix error when setting default btrfs subvol - continued

### DIFF
--- a/astpk.py
+++ b/astpk.py
@@ -14,6 +14,7 @@ args = list(sys.argv)
 # General code cleanup
 # Maybe port for other distros?
 # A clean way to completely unistall ast
+# Implement AUR package maintenance between snapshots
 # -----------------
 
 # Directories

--- a/main.py
+++ b/main.py
@@ -280,9 +280,11 @@ def main(args):
         os.system("btrfs sub snap -r /mnt/.snapshots/boot/boot-tmp /mnt/.snapshots/boot/boot-1")
         os.system("btrfs sub snap -r /mnt/.snapshots/etc/etc-tmp /mnt/.snapshots/etc/etc-1")
         os.system("btrfs sub snap /mnt/.snapshots/rootfs/snapshot-1 /mnt/.snapshots/rootfs/snapshot-tmp")
+        os.system("arch-chroot /mnt btrfs sub set-default /.snapshots/rootfs/snapshot-tmp")
 
     else:
         os.system("btrfs sub snap /mnt/.snapshots/rootfs/snapshot-0 /mnt/.snapshots/rootfs/snapshot-tmp")
+        os.system("arch-chroot /mnt btrfs sub set-default /.snapshots/rootfs/snapshot-tmp")
 
     os.system("cp -r /mnt/root/. /mnt/.snapshots/root/")
     os.system("cp -r /mnt/tmp/. /mnt/.snapshots/tmp/")


### PR DESCRIPTION
This is an addendum to [commit](https://github.com/astos/astos/commit/9fe92ba44e0d86896d02deb4f5f8f6447a475855). It was left off!