### PR TITLE
add new ast-sync operation, make ast a global executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ python3 main.py /dev/<partition> /dev/<drive> /dev/<efi part> # Skip the EFI par
 ## Additional documentation
 * It is advised to refer to the [Arch wiki](https://wiki.archlinux.org/) for documentation not part of this project
 * Report issues/bugs on the [Github issues page](https://github.com/astos/astos/issues)
+* **HINT: you can use `ast help` to get a quick cheatsheet of all available commands**
 
 #### Base snapshot
 * The snapshot ```0``` is reserved for the base system snapshot, it cannot be changed and can only be updated using ```ast base-update```

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Clone repository
 
 ```
 git clone "https://github.com/astos/astos"  
-cd astos  
+cd astOS  
 ```
 Partition and format drive
 
@@ -282,6 +282,8 @@ ast tree-rmpkg <tree> <pacakge or packages>
 
 #### Updating
 * It is advised to clone a snapshot before updating it, so you can roll back in case of failure
+* This update only updates the system packages, in order to update ast itself see [this section](https://github.com/astos/astos#updating-ast-itself)
+ 
 
 * To update a single snapshot
 
@@ -339,21 +341,12 @@ ast deploy <snapshot>
 ```
 
 #### Updating ast itself
+* ast doesn't get updated alongside the system when `ast upgrade` is used
 * sometimes it may be necessary to update ast itself
-* this can be done in a few steps:
+* ast can be updated with a single command
 
 ```
-git clone "https://github.com/astos/astos"
-cd astOS
-cp astpk.py ast 
-chmod +x ast
-cp ./ast /var/astpk/ast  # Copy new ast to /var, accessible from all snapshots
-ast trun <snapshot> cp /var/astpk/ast /usr/bin/ast  # Copy over new ast
-ast clone 0
-ast run <clone of 0> cp /var/astpk/ast /usr/bin/ast  # Now we update snapshot 0 in a clone  
-btrfs sub del /.snapshots/rootfs/snapshot-0  # Here we manually replace snapshot 0 with the updated snapshot
-btrfs sub snap -r /.snapshots/rootfs/snapshot-<clone of 0> /.snapshots/rootfs/snapshot-0
-ast del <clone of 0>  # Remove temporary snapshot
+ast ast-sync
 ```
 
 #### Debugging ast

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Clone repository
 
 ```
 git clone "https://github.com/astos/astos"  
-cd astOS  
+cd astos  
 ```
 Partition and format drive
 

--- a/astpk.py
+++ b/astpk.py
@@ -221,6 +221,7 @@ def clone_under(snapshot, branch):
         print(f"Branch {i} added under snapshot {snapshot}.")
 
 #   Lock ast
+#   Currently this lock is ignored
 def ast_lock():
     os.system("touch /.snapshots/ast/lock-disable")
 
@@ -726,6 +727,16 @@ def switchtmp():
     grubconf.close()
     os.system("umount /etc/mnt/boot >/dev/null 2>&1")
 
+#   Update ast itself
+def ast_sync():
+    cdir = os.getcwd()
+    os.chdir("/tmp")
+    excode = str(os.system("curl -O 'https://raw.githubusercontent.com/astos/astos/main/astpk.py'"))
+    if int(excode) == 0:
+        os.system("cp ./astpk.py /.snapshots/ast/ast")
+        os.system("chmod +x /.snapshots/ast/ast")
+    os.chdir(cdir)
+
 # Clear all temporary snapshots
 def tmpclear():
     os.system(f"btrfs sub del /.snapshots/etc/etc-chr* >/dev/null 2>&1")
@@ -857,6 +868,10 @@ def main(args):
     elif arg == "base-update" or arg == "bu" and (lock != True):
         ast_lock()
         update_base()
+        ast_unlock()
+    elif arg == "ast-sync" and (lock != True):
+        ast_lock()
+        ast_sync()
         ast_unlock()
     elif arg == "sync" or arg == "tree-sync" and (lock != True):
         ast_lock()

--- a/astpk.py
+++ b/astpk.py
@@ -727,6 +727,38 @@ def switchtmp():
     grubconf.close()
     os.system("umount /etc/mnt/boot >/dev/null 2>&1")
 
+
+#   Show some basic ast commands
+def ast_help():
+    print("all ast commands, aside from 'ast tree' must be used with root permissions!")
+    print("\n\ntree manipulation commands:")
+    print("\ttree - show the snapshot tree")
+    print("\tcurrent - return current snapshot number")
+    print("\tdesc <snapshot> <description> - set a description for snapshot by number")
+    print("\tdel <tree> - delete a tree and all it's branches recursively")
+    print("\tchroot <snapshot> - open a root shell inside specified snapshot")
+    print("\tlive-chroot - open a read-write shell inside currently booted snapshot (changes are discarded on new deployment)")
+    print("\trun <snapshot> <command> - execute command inside another snapshot")
+    print("\ttree-run <tree> <command> - execute command inside another snapshot and all snapshots below it")
+    print("\tclone <snapshot> - create a copy of snapshot")
+    print("\tbranch <snapshot> - create a new branch from snapshot")
+    print("\tcbranch <snapshot> - copy snapshot under same parent branch")
+    print("\tubranch <parent> <snapshot> - copy snapshot under specified parent")
+    print("\tnew - create a new base snapshot")
+    print("\tdeploy <snapshot> - deploy a snapshot for next boot")
+    print("\tbase-update - update the base image")
+    print("\n\npackage management commands:")
+    print("\tinstall <snapshot> <package> - install a package inside specified snapshot")
+    print("\tsync <tree> - sync package and configuration changes recursively, requires an internet connection")
+    print("\tforce-sync <tree> - same thing as sync but doesn't update snapshots, potentially riskier")
+    print("\tremove <snapshot> <package(s)> - remove package(s) from snapshot")
+    print("\ttree-rmpkg <tree> <package(s)> - remove package(s) from tree recursively")
+    print("\tupgrade <snapshot> - update all packages in snapshot")
+    print("\ttree-upgrade <tree> - update all packages in snapshot recursively")
+    print("\trollback - rollback the deployment to the last booted snapshot")
+    print("\n\nto update ast itself use 'ast ast-sync'")
+
+
 #   Update ast itself
 def ast_sync():
     cdir = os.getcwd()
@@ -777,7 +809,11 @@ def main(args):
     fstreepath = str("/.snapshots/ast/fstree") # Path to fstree file
     fstree = importer.import_(import_tree_file("/.snapshots/ast/fstree")) # Import fstree file
     # Recognize argument and call appropriate function
-    arg = args[1]
+    if len(args) > 1:
+        arg = args[1]
+    else:
+        print("You need to specify an operation, see 'ast help' for help.")
+        sys.exit()
     if isChroot == True and ("--chroot" not in args):
         print("Please don't use ast inside a chroot!")
     elif lock == True:
@@ -872,6 +908,8 @@ def main(args):
         ast_lock()
         update_base()
         ast_unlock()
+    elif arg == "help":
+        ast_help()
     elif arg == "ast-sync" and (lock != True):
         ast_lock()
         ast_sync()

--- a/astpk.py
+++ b/astpk.py
@@ -735,6 +735,9 @@ def ast_sync():
     if int(excode) == 0:
         os.system("cp ./astpk.py /.snapshots/ast/ast")
         os.system("chmod +x /.snapshots/ast/ast")
+        print("ast updated succesfully.")
+    else:
+        print("error: failed to download ast")
     os.chdir(cdir)
 
 # Clear all temporary snapshots

--- a/main.py
+++ b/main.py
@@ -103,7 +103,7 @@ def main(args):
     os.system(f"echo 'ID=astos' >> /mnt/etc/os-release")
     os.system(f"echo 'BUILD_ID=rolling' >> /mnt/etc/os-release")
     os.system(f"echo 'ANSI_COLOR=\"38;2;23;147;209\"' >> /mnt/etc/os-release")
-    os.system(f"echo 'HOME_URL=\"https://github.com/CuBeRJAN/astOS\"' >> /mnt/etc/os-release")
+    os.system(f"echo 'HOME_URL=\"https://github.com/astos/astos\"' >> /mnt/etc/os-release")
     os.system(f"echo 'LOGO=astos-logo' >> /mnt/etc/os-release")
     os.system(f"cp -r /mnt/var/lib/pacman/* /mnt/usr/share/ast/db")
     os.system(f"sed -i s,\"#DBPath      = /var/lib/pacman/\",\"DBPath      = /usr/share/ast/db/\",g /mnt/etc/pacman.conf")
@@ -126,6 +126,8 @@ def main(args):
     os.system("sed -i '0,/@boot/{s,@boot,@.snapshots/boot/boot-tmp,}' /mnt/etc/fstab")
     os.system("mkdir -p /mnt/.snapshots/ast/snapshots")
 
+    os.system("cp ./astpk.py /mnt/.snapshots/ast/ast")
+    os.system("arch-chroot /mnt chmod +x /.snapshots/ast/ast")
     os.system("arch-chroot /mnt ln -s /.snapshots/ast /var/lib/ast")
 
     clear()
@@ -150,8 +152,7 @@ def main(args):
     os.system(f"arch-chroot /mnt grub-install {args[2]}")
     os.system(f"arch-chroot /mnt grub-mkconfig {args[2]} -o /boot/grub/grub.cfg")
     os.system("sed -i '0,/subvol=@/{s,subvol=@,subvol=@.snapshots/rootfs/snapshot-tmp,g}' /mnt/boot/grub/grub.cfg")
-    os.system("cp ./astpk.py /mnt/usr/local/sbin/ast")
-    os.system("arch-chroot /mnt chmod +x /usr/local/sbin/ast")
+    os.system("arch-chroot /mnt ln -s /.snapshots/ast/ast /usr/local/sbin/ast")
     os.system("btrfs sub snap -r /mnt /mnt/.snapshots/rootfs/snapshot-0")
     os.system("btrfs sub create /mnt/.snapshots/etc/etc-tmp")
     os.system("btrfs sub create /mnt/.snapshots/var/var-tmp")


### PR DESCRIPTION
ast is now shared for all snapshots, this makes keeping it updated much easier
there's also a new ast-sync operation that automatically updates ast